### PR TITLE
Filter js middleware

### DIFF
--- a/lib/pipa.js
+++ b/lib/pipa.js
@@ -89,10 +89,12 @@ Pipa.prototype = {
 	__init__middleware: function (routes) {
 		var self = this;
 
-		fs.readdirSync(this.middlewareBasePath()).filter(function (file) {
+	
+		fs.readdirSync(this.middlewareBasePath()).filter(file => file.match(/\.js$/) || file.match(/\.coffee$/)).forEach(function (file) {
 			var middlewareName = file.replace(/\.js$/, '').replace(/\.coffee$/, '');
 			self.middlewares[middlewareName] = require(path.join(self.middlewareBasePath(), middlewareName));
 		});
+
 
 		for (var root in routes) {
 			if (root && routes[root]) {


### PR DESCRIPTION
Add filter when loading js/coffe in middleware folder. So another file will not be loaded by pipa.